### PR TITLE
Chemical substance images are broken in Essay questions

### DIFF
--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -44,6 +44,22 @@ use filter_manager;
  */
 class plugininfo extends plugin implements plugin_with_buttons, plugin_with_menuitems, plugin_with_configuration {
 
+    #[\Override]
+    public static function is_enabled(
+            context $context,
+            array $options,
+            array $fpoptions,
+            ?editor $editor = null
+    ): bool {
+        // Disabled if:
+        // - Not logged in or guest.
+        // - Files are not allowed.
+        // - Only URL are supported.
+        $canhavefiles = !empty($options['maxfiles']);
+        $canhaveexternalfiles = !empty($options['return_types']) && ($options['return_types'] & FILE_EXTERNAL);
+        return isloggedin() && !isguestuser() && $canhavefiles && $canhaveexternalfiles;
+    }
+
     /**
      * return available buttons
      * @return string[]


### PR DESCRIPTION
Currently, this plugin is not work in essay question is set to not allow attached files. (In Moodle, some editors allow embedded files, and other don't. That is probably why this works in some places an not others.)

Steps : 
- Click on start preview (The quiz activity/questionnaire contains essay type questions) 
- In TinyMCE box, Click on "Chemical substance" icon 
- To draw molecular formulas use the available options in chemdoodle
- Click on resize to resize image, and click on save images 
- Once saved, click on Finish attempt
- Check the review

**Actual result:** 
Chemical substance images are broken in Essay questions
for more details, please check the video evidence 

https://github.com/user-attachments/assets/9dfd1833-47fc-4e60-9ab6-8731a5b32612

![image](https://github.com/user-attachments/assets/677574fd-8ed7-43a0-a742-d50291c7b209)

**Expected Result :** 
Chemdoodle images should not appear in Essay question